### PR TITLE
malloc.h is not available on osx

### DIFF
--- a/extra/Python/hash.c
+++ b/extra/Python/hash.c
@@ -8,7 +8,6 @@
 
 #include <sys/types.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 
 #include "hash.h"


### PR DESCRIPTION
stdlib.h provides malloc/free and is already included