### PR TITLE
Use lpsolve include prefix

### DIFF
--- a/extra/Python/pythonmod.h
+++ b/extra/Python/pythonmod.h
@@ -14,7 +14,7 @@
 #include "numpy/arrayobject.h"
 #endif
 
-#include "lp_lib.h"
+#include <lpsolve/lp_lib.h>
 
 #define quotechar "'"
 #define drivername lpsolve


### PR DESCRIPTION
Now that this is a separate project, we cannot rely on lpsolve headers to be present somewhere in the sources, but installed a system prefix, usually these are installed under `/usr/include/lpsolve/`, like in debian etc.