### PR TITLE
fix: input string list by python

### DIFF
--- a/extra/Python/pythonmod.c
+++ b/extra/Python/pythonmod.c
@@ -896,7 +896,7 @@ strArray GetCellCharItems(structlpsolvecaller *lpsolvecaller, int element, int l
                     ErrMsgTxt(lpsolvecaller, "invalid vector (non-string item).");
     		}
         #ifdef PY3K
-    		if ((PyBytes_AsStringAndSize(item, &ptr, &size1) != 0) ||
+    		if(!(ptr = PyUnicode_AsUTF8AndSize(item,&size1)) ||
 		#else
     		if ((PyString_AsStringAndSize(item, &ptr, &size1) != 0) ||
 		#endif

--- a/extra/Python/pythonmod.h
+++ b/extra/Python/pythonmod.h
@@ -14,7 +14,7 @@
 #include "numpy/arrayobject.h"
 #endif
 
-#include <lpsolve/lp_lib.h>
+#include "lp_lib.h"
 
 #define quotechar "'"
 #define drivername lpsolve

--- a/extra/Python/pythonmod.h
+++ b/extra/Python/pythonmod.h
@@ -14,7 +14,7 @@
 #include "numpy/arrayobject.h"
 #endif
 
-#include "lp_lib.h"
+#include <lpsolve/lp_lib.h>
 
 #define quotechar "'"
 #define drivername lpsolve


### PR DESCRIPTION
Fix issue #5: The method PyBytes_AsStringAndSize expect a null-ternimated char that it is not check by  PyUnicode_Check. The method PyUnicode_AsUTF8AndSize will work fine.